### PR TITLE
Add sandbox XP multiplier options for TOC perks

### DIFF
--- a/42/media/lua/shared/Translate/EN/Sandbox.json
+++ b/42/media/lua/shared/Translate/EN/Sandbox.json
@@ -5,5 +5,8 @@
     "Sandbox_TOC_SurgeonAbilityImportance": "Relevance of surgeon doctor ability",
     "Sandbox_TOC_EnableZombieAmputations": "Enable Zombie amputations",
     "Sandbox_TOC_ZombieAmputationDamageThreshold": "Zombie amputations damage treshold",
-    "Sandbox_TOC_ZombieAmputationDamageChance": "Zombie amputations damage chance"
+    "Sandbox_TOC_ZombieAmputationDamageChance": "Zombie amputations damage chance",
+    "Sandbox_TOC_XPMultiplierSide_L": "Left Side XP Multiplier",
+    "Sandbox_TOC_XPMultiplierSide_R": "Right Side XP Multiplier",
+    "Sandbox_TOC_XPMultiplierProstFamiliarity": "Prosthesis Familiarity XP Multiplier"
 }

--- a/42/media/sandbox-options.txt
+++ b/42/media/sandbox-options.txt
@@ -27,3 +27,31 @@ option TOC.SurgeonAbilityImportance
     page = TOC,
     translation = TOC_SurgeonAbilityImportance,
 }
+
+option MultiplierConfig.Side_L
+{
+    type = double,
+    min = 0.0,
+    max = 1000.0,
+    default = 1.0,
+    page = TOC,
+    translation = TOC_XPMultiplierSide_L,
+}
+option MultiplierConfig.Side_R
+{
+    type = double,
+    min = 0.0,
+    max = 1000.0,
+    default = 1.0,
+    page = TOC,
+    translation = TOC_XPMultiplierSide_R,
+}
+option MultiplierConfig.ProstFamiliarity
+{
+    type = double,
+    min = 0.0,
+    max = 1000.0,
+    default = 1.0,
+    page = TOC,
+    translation = TOC_XPMultiplierProstFamiliarity,
+}


### PR DESCRIPTION
Fixes #277, fixes #263. Related: #268, #222.

With `MultiplierConfig.GlobalToggle` off, the engine's `XP.AddXP` looks up a `MultiplierConfig.<perkId>` sandbox option by name. TOC perks had none, so the lookup returned null and every XP tick threw a NullPointerException, meaning no Side or Prosthesis XP was ever awarded. This cannot be worked around from Lua: on 42.20.4, `addXp`, `addXpNoMultiplier` and the server-side path all end in the same overload that does the lookup. The fix registers `MultiplierConfig.Side_L`, `Side_R` and `ProstFamiliarity` in `sandbox-options.txt` with English labels, which also gives admins per-skill multipliers for the TOC skills.

Tested on my 42.20.4 dedicated server with the global toggle off and clients on the Workshop build. XP accrues normally in multiplayer and the server console stays free of NullPointerException lines.
