### PR TITLE
Fix/279 bite on cut limb v2

### DIFF
--- a/42/media/lua/client/TOC/Controllers/LocalPlayerController.lua
+++ b/42/media/lua/client/TOC/Controllers/LocalPlayerController.lua
@@ -245,6 +245,70 @@ end
 
 Events.OnPlayerGetDamage.Add(LocalPlayerController.OnGetDamage)
 
+--* Bite-on-cut-limb polling (issue #279) *--
+-- Why this exists alongside HandleDamage above (read before touching either):
+--  - HandleDamage is REACTIVE: it runs on OnPlayerGetDamage, which the engine does
+--    NOT fire for MP zombie hits (victim client forwards the hit via
+--    sendZombieHit and applies nothing; the server rolls damage and pushes full
+--    BodyDamage back via PlayerDamage packet, eventlessly). So HandleDamage never
+--    sees the bite moment in MP - only later INFECTION ticks, if at all.
+--  - This poll is DETECTIVE: it runs on OnPlayerUpdate (local-player-only on
+--    clients), spots a bite sitting on an already-cut limb, clears it locally for
+--    instant display relief via HealArea, and - the part that actually fixes MP -
+--    asks the server to clear it authoritatively via RequestSanitizeCutLimb.
+--    Client Lua can never push BodyDamage itself (syncBodyPart is a no-op outside
+--    the server), hence the round-trip.
+-- Both paths are idempotent: clearing already-clean state is a cheap no-op loop.
+-- Throttle state below belongs ONLY to this poll; it shares nothing with the
+-- hasBeenDamaged lock above.
+
+---How often (in OnPlayerUpdate ticks) to scan cut limbs. ~60 ticks ~= 1 second.
+LocalPlayerController.sanitizePollInterval = 60
+---Minimum ticks between two sanitize requests for the SAME limb. Bounds packets.
+LocalPlayerController.sanitizeRequestCooldown = 600
+LocalPlayerController.sanitizePollTick = 0
+---@type table<string, integer> limbName -> poll tick of last sent request
+LocalPlayerController.sanitizeLastRequestTick = {}
+
+---@param character IsoPlayer|IsoGameCharacter
+function LocalPlayerController.PollCutLimbsForBites(character)
+    if character ~= getPlayer() then return end
+
+    LocalPlayerController.sanitizePollTick = LocalPlayerController.sanitizePollTick + 1
+    if LocalPlayerController.sanitizePollTick % LocalPlayerController.sanitizePollInterval ~= 0 then return end
+
+    local playerObj = getPlayer()
+    local dcInst = DataController.GetInstance(playerObj:getUsername())
+    if not dcInst or not dcInst:getIsDataReady() then return end
+    if not dcInst:getIsAnyLimbCut() then return end
+
+    local bd = playerObj:getBodyDamage()
+    if not bd then return end
+
+    for i = 1, #StaticData.LIMBS_STR do
+        local limbName = StaticData.LIMBS_STR[i]
+        if dcInst:getIsCut(limbName) then
+            local bptEnum = StaticData.LIMBS_TO_BODYLOCS_IND_BPT[limbName]
+            local bodyPart = bptEnum and bd:getBodyPart(bptEnum) or nil
+            if bodyPart and (bodyPart:bitten() or bodyPart:IsInfected()) then
+                -- Local relief: correct in SP, display-only in MP (server re-pushes).
+                LocalPlayerController.HealArea(bodyPart)
+
+                local lastReq = LocalPlayerController.sanitizeLastRequestTick[limbName] or -LocalPlayerController.sanitizeRequestCooldown
+                if LocalPlayerController.sanitizePollTick - lastReq >= LocalPlayerController.sanitizeRequestCooldown then
+                    LocalPlayerController.sanitizeLastRequestTick[limbName] = LocalPlayerController.sanitizePollTick
+                    TOC_DEBUG.print("Requesting server sanitize for bite on missing limb - " .. limbName)
+                    sendClientCommand(CommandsData.modules.TOC_RELAY,
+                        CommandsData.server.Relay.RequestSanitizeCutLimb,
+                        {limbName = limbName})
+                end
+            end
+        end
+    end
+end
+
+Events.OnPlayerUpdate.Add(LocalPlayerController.PollCutLimbsForBites)
+
 --* Amputation Loop handling *--
 
 ---Updates the cicatrization process, run when a limb has been cut. Run it every 1 hour

--- a/42/media/lua/client/TOC/Controllers/LocalPlayerController.lua
+++ b/42/media/lua/client/TOC/Controllers/LocalPlayerController.lua
@@ -70,6 +70,10 @@ end
 --* Health *--
 
 ---Used to heal an area that has been cut previously. There's an exception for bites, those are managed differently
+---DRAFT FIX for #279: bites can still roll on the vanilla BodyPart of an
+---already-amputated limb (amputation is modData + stump clothing, prosthesis is
+---only a toc:armprost_* item BodyLocation). Clear bite/infection timers too,
+---otherwise the health panel keeps showing "Bitten" on a missing limb.
 ---@param bodyPart BodyPart
 function LocalPlayerController.HealArea(bodyPart)
 
@@ -83,7 +87,12 @@ function LocalPlayerController.HealArea(bodyPart)
     bodyPart:setBleedingTime(0)
 
     bodyPart:SetBitten(false)
-    --bodyPart:setBiteTime(0)
+    -- DRAFT #279: SetBitten(false) alone leaves BiteTime running, so HasInjury()
+    -- stays true and ISHealthPanel keeps listing the missing limb. Guarded for
+    -- B42 server-side API differences.
+    if bodyPart.setBiteTime then bodyPart:setBiteTime(0) end
+    if bodyPart.setInfected then bodyPart:setInfected(false) end
+    if bodyPart.setInfectionTime then bodyPart:setInfectionTime(0) end
     bodyPart:SetInfected(false)
 
     bodyPart:setCut(false)
@@ -180,9 +189,16 @@ function LocalPlayerController.HandleDamage(character)
             end
 
             -- Special case for bites\zombie infections
-            if bodyPart:IsInfected() then
+            -- DRAFT #279: bitten() can be true without IsInfected() yet; both mean
+            -- "zombie hit a missing limb" and must be cleared + synced, otherwise
+            -- the bite persists on the panel with no valid re-amputation target.
+            if bodyPart:bitten() or bodyPart:IsInfected() then
                 TOC_DEBUG.print("Healed from zombie infection - " .. limbName)
                 LocalPlayerController.HealZombieInfection(bd, limbName, dcInst)
+                modDataNeedsUpdate = true
+            elseif dcInst:getIsInfected(limbName) then
+                -- Injury was cleared above but the modData flag stayed stale.
+                dcInst:setIsInfected(limbName, false)
                 modDataNeedsUpdate = true
             end
         else

--- a/42/media/lua/server/TOC/Controllers/ServerDamageSanitizer.lua
+++ b/42/media/lua/server/TOC/Controllers/ServerDamageSanitizer.lua
@@ -1,32 +1,37 @@
 require("TOC/Debug")
 local StaticData = require("TOC/StaticData")
 --------------------------------------------
--- DRAFT SPIKE for #279 (server-authoritative, MP only).
+-- On-demand sanitizer for #279. There is deliberately NO global sweep here: the
+-- server never enumerates players (see review notes). Detection runs on each
+-- client (LocalPlayerController.PollCutLimbsForBites, local-player-only) and the
+-- server acts solely when asked, for the asking player, via RequestSanitizeCutLimb.
 --
 -- Problem: a zombie bite can roll on the vanilla BodyPart of an already-amputated
 -- limb (amputation is modData + stump clothing; a prosthesis is only a
--- toc:armprost_* item BodyLocation, never a damage target). The client-only
--- LocalPlayerController.HandleDamage heal may be overwritten by the
--- server-authoritative BodyDamage in B42.13+, so the bite persists on a limb
--- that no longer exists and CutLimbInteractionHandler:isValid correctly refuses
--- to re-cut the same limbName.
+-- toc:armprost_* item BodyLocation, never a damage target). Zombie-hit BodyDamage
+-- is server-simulated (AddRandomDamageFromZombie early-returns on clients; the
+-- server pushes full state back via PlayerDamage packet), and client Lua can never
+-- push BodyDamage back (syncBodyPart is a no-op outside the server), so the bite
+-- persists on a limb that no longer exists while CutLimbInteractionHandler:isValid
+-- correctly refuses to re-cut the same limbName.
 --
--- This sweep clears bite/infection state on cut limbs server-side, using the same
--- syncBodyPart primitive AmputationHandler already relies on. Hourly cadence is
--- plenty fast against the Knox mortality clock; an opportunistic per-hit hook
--- (e.g. from UpdateDataControllerFromClient) can be added later if needed.
+-- This clears bite/infection state on cut limbs using the same syncBodyPart
+-- primitive AmputationHandler already relies on.
 --
 -- TODO(playtest): confirm no interference with healInfection's <20 curability
 -- window and with ignored-part (Torso_Upper etc.) infections, which must NOT be
--- cleared here.
+-- cleared here (this loop only visits the 6 arm limbs, never ignored parts).
 ---@class ServerDamageSanitizer
 local ServerDamageSanitizer = {}
 
----Clear bite/infection state on the cut limbs of one player. No-ops welcome:
----runs hourly for everyone online, so it must be cheap when there is nothing to do.
+---Clear bite/infection state on the cut limbs of one player. Idempotent:
+---re-running on clean state is a cheap no-op loop, safe under double execution
+---(e.g. listen-server host) and repeated client requests.
 ---@param playerObj IsoPlayer
 function ServerDamageSanitizer.SanitizePlayer(playerObj)
-    if not playerObj or not isServer() then return end
+    -- Refuse pure-client context only. SP (neither client nor server) shares one
+    -- Lua state, so direct mutation applies and syncBodyPart harmlessly no-ops.
+    if not playerObj or (isClient() and not isServer()) then return end
 
     local DataController = require("TOC/Controllers/DataController")
     local dcInst = DataController.GetInstance(playerObj:getUsername())
@@ -57,19 +62,5 @@ function ServerDamageSanitizer.SanitizePlayer(playerObj)
         end
     end
 end
-
----Hourly fallback sweep over online players. Each player is isolated with pcall
----so one bad BodyPart never aborts the rest.
-local function SanitizeAllOnlinePlayers()
-    if not isServer() then return end
-    local players = getOnlinePlayers()
-    if not players then return end
-    for i = 0, players:size() - 1 do
-        local ok, err = pcall(ServerDamageSanitizer.SanitizePlayer, players:get(i))
-        if not ok then TOC_DEBUG.print("ServerDamageSanitizer error: " .. tostring(err)) end
-    end
-end
-
-Events.EveryHours.Add(SanitizeAllOnlinePlayers)
 
 return ServerDamageSanitizer

--- a/42/media/lua/server/TOC/Controllers/ServerDamageSanitizer.lua
+++ b/42/media/lua/server/TOC/Controllers/ServerDamageSanitizer.lua
@@ -1,0 +1,75 @@
+require("TOC/Debug")
+local StaticData = require("TOC/StaticData")
+--------------------------------------------
+-- DRAFT SPIKE for #279 (server-authoritative, MP only).
+--
+-- Problem: a zombie bite can roll on the vanilla BodyPart of an already-amputated
+-- limb (amputation is modData + stump clothing; a prosthesis is only a
+-- toc:armprost_* item BodyLocation, never a damage target). The client-only
+-- LocalPlayerController.HandleDamage heal may be overwritten by the
+-- server-authoritative BodyDamage in B42.13+, so the bite persists on a limb
+-- that no longer exists and CutLimbInteractionHandler:isValid correctly refuses
+-- to re-cut the same limbName.
+--
+-- This sweep clears bite/infection state on cut limbs server-side, using the same
+-- syncBodyPart primitive AmputationHandler already relies on. Hourly cadence is
+-- plenty fast against the Knox mortality clock; an opportunistic per-hit hook
+-- (e.g. from UpdateDataControllerFromClient) can be added later if needed.
+--
+-- TODO(playtest): confirm no interference with healInfection's <20 curability
+-- window and with ignored-part (Torso_Upper etc.) infections, which must NOT be
+-- cleared here.
+---@class ServerDamageSanitizer
+local ServerDamageSanitizer = {}
+
+---Clear bite/infection state on the cut limbs of one player. No-ops welcome:
+---runs hourly for everyone online, so it must be cheap when there is nothing to do.
+---@param playerObj IsoPlayer
+function ServerDamageSanitizer.SanitizePlayer(playerObj)
+    if not playerObj or not isServer() then return end
+
+    local DataController = require("TOC/Controllers/DataController")
+    local dcInst = DataController.GetInstance(playerObj:getUsername())
+    if not dcInst or not dcInst:getIsDataReady() then return end
+    if not dcInst:getIsAnyLimbCut() then return end
+
+    local bd = playerObj:getBodyDamage()
+    if not bd then return end
+
+    for i = 1, #StaticData.LIMBS_STR do
+        local limbName = StaticData.LIMBS_STR[i]
+        if dcInst:getIsCut(limbName) then
+            local bptEnum = StaticData.LIMBS_TO_BODYLOCS_IND_BPT[limbName]
+            local part = bptEnum and bd:getBodyPart(bptEnum) or nil
+            if part and (part:bitten() or part:IsInfected()) then
+                TOC_DEBUG.print("ServerDamageSanitizer: clearing bite on missing limb - " .. limbName)
+                part:SetBitten(false)
+                if part.setBiteTime then part:setBiteTime(0) end
+                part:SetInfected(false)
+                if part.setInfected then part:setInfected(false) end
+                if part.setInfectionTime then part:setInfectionTime(0) end
+                syncBodyPart(part, 0xFFFFFFFFFFF)
+                dcInst:setIsInfected(limbName, false)
+            elseif part and dcInst:getIsInfected(limbName) and not part:HasInjury() then
+                -- Wound visual already clean but the modData flag stayed stale.
+                dcInst:setIsInfected(limbName, false)
+            end
+        end
+    end
+end
+
+---Hourly fallback sweep over online players. Each player is isolated with pcall
+---so one bad BodyPart never aborts the rest.
+local function SanitizeAllOnlinePlayers()
+    if not isServer() then return end
+    local players = getOnlinePlayers()
+    if not players then return end
+    for i = 0, players:size() - 1 do
+        local ok, err = pcall(ServerDamageSanitizer.SanitizePlayer, players:get(i))
+        if not ok then TOC_DEBUG.print("ServerDamageSanitizer error: " .. tostring(err)) end
+    end
+end
+
+Events.EveryHours.Add(SanitizeAllOnlinePlayers)
+
+return ServerDamageSanitizer

--- a/42/media/lua/server/TOC/ServerRelayCommands.lua
+++ b/42/media/lua/server/TOC/ServerRelayCommands.lua
@@ -36,25 +36,28 @@ function ServerRelayCommands.UpdateDataControllerFromClient(playerObj, args)
 
     end
 
-    if args.isInfected then
+    -- DRAFT #279: `if args.flag` drops `false`, so a client clearing isInfected
+    -- (bite on missing limb healed) never reached the server and the flag stayed
+    -- stale. Check for nil instead so both true and false propagate.
+    if args.isInfected ~= nil then
         h:setIsInfected(args.limbName, args.isInfected)
         TOC_DEBUG.print("isInfected = " .. tostring(args.isInfected))
 
     end
 
-    if args.isCauterized then
+    if args.isCauterized ~= nil then
         h:setIsCauterized(args.limbName, args.isCauterized)
         TOC_DEBUG.print("isCauterized = " .. tostring(args.isCauterized))
 
     end
 
-    if args.isCicatrized then
+    if args.isCicatrized ~= nil then
         h:setIsCicatrized(args.limbName, args.isCicatrized)
         TOC_DEBUG.print("iscicatrized = " .. tostring(args.isCicatrized))
 
     end
 
-    if args.isIgnoredPartInfected then
+    if args.isIgnoredPartInfected ~= nil then
         h:setIsIgnoredPartInfected(args.isIgnoredPartInfected)
         TOC_DEBUG.print("isignoredpartinfected = " .. tostring(args.isIgnoredPartInfected))
 

--- a/42/media/lua/server/TOC/ServerRelayCommands.lua
+++ b/42/media/lua/server/TOC/ServerRelayCommands.lua
@@ -189,6 +189,35 @@ function ServerRelayCommands.RelayForcedAmputation(adminObj, args)
     h:apply(patientPl)
 end
 
+---Clear a bite sitting on the requesting player's own already-amputated limb (#279).
+---The client detects it (it can only ever see itself); the server validates and
+---clears it authoritatively, since client Lua cannot push BodyDamage. Sender is
+---implicitly scoped: we only ever touch playerObj's own data, so a crafted packet
+---can at most clear the sender's own phantom bites - nothing it couldn't already
+---achieve by playing normally.
+---@param playerObj IsoPlayer
+---@param args requestSanitizeCutLimbParams
+function ServerRelayCommands.RequestSanitizeCutLimb(playerObj, args)
+    local limbName = args and args.limbName or nil
+    if type(limbName) ~= "string" or StaticData.LIMBS_TO_BODYLOCS_IND_BPT[limbName] == nil then
+        TOC_DEBUG.print("RequestSanitizeCutLimb rejected: bad limbName from " .. playerObj:getUsername())
+        return
+    end
+
+    local DataController = require("TOC/Controllers/DataController")
+    local dcInst = DataController.GetInstance(playerObj:getUsername())
+    if not dcInst or not dcInst:getIsDataReady() then return end
+    if not dcInst:getIsCut(limbName) then
+        TOC_DEBUG.print("RequestSanitizeCutLimb rejected: limb not cut - " .. limbName)
+        return
+    end
+
+    TOC_DEBUG.print("RequestSanitizeCutLimb accepted for " .. playerObj:getUsername() .. " - " .. limbName)
+    local ServerDamageSanitizer = require("TOC/Controllers/ServerDamageSanitizer")
+    local ok, err = pcall(ServerDamageSanitizer.SanitizePlayer, playerObj)
+    if not ok then TOC_DEBUG.print("RequestSanitizeCutLimb error: " .. tostring(err)) end
+end
+
 ---Apply bleeding to the patient's wound server-side, relayed from client perform() in MP
 ---@param playerObj IsoPlayer sender (validated against patientNum — players can only bleed themselves)
 ---@param args relayTriggerBleedParams

--- a/42/media/lua/shared/TOC/CommandsData.lua
+++ b/42/media/lua/shared/TOC/CommandsData.lua
@@ -49,6 +49,11 @@ CommandsData.server = {
 
         RelayTriggerBleed = "RelayTriggerBleed",                         ---@alias relayTriggerBleedParams {patientNum : number, limbName : string, bleedingTime : number}
 
+        --* BITE ON CUT LIMB (#279) *--
+        -- Client detected a bite on its own already-amputated limb and asks the
+        -- server (BodyDamage owner in MP) to clear it authoritatively.
+        RequestSanitizeCutLimb = "RequestSanitizeCutLimb",                 ---@alias requestSanitizeCutLimbParams {limbName : string}
+
         --* PROSTHESES *--
         RelayProsthesisState = "RelayProsthesisState",                   ---@alias relayProsthesisStateParams {group : string, isEquipped : boolean}
 


### PR DESCRIPTION
For 2.4.1.
+ Should finally resolve random issues with a more aggressive check for amputated limbs and their dependencies. (#279)
+ some other random fixes related to errors in the main menu/after apply (#281)